### PR TITLE
feat: add url filter and localize method for docs

### DIFF
--- a/fixtures/simple/amagaki.ts
+++ b/fixtures/simple/amagaki.ts
@@ -11,6 +11,10 @@ export default function (pod: Pod) {
         path: '/static/js/',
         staticDir: '/dist/js/',
       },
+      {
+        path: '/static/images/',
+        staticDir: '/static/images/',
+      },
     ],
   });
 }

--- a/fixtures/simple/amagaki.ts
+++ b/fixtures/simple/amagaki.ts
@@ -1,0 +1,16 @@
+import {Pod} from '../../';
+
+export default function (pod: Pod) {
+  pod.configure({
+    staticRoutes: [
+      {
+        path: '/static/css/',
+        staticDir: '/dist/css/',
+      },
+      {
+        path: '/static/js/',
+        staticDir: '/dist/js/',
+      },
+    ],
+  });
+}

--- a/fixtures/simple/views/base.njk
+++ b/fixtures/simple/views/base.njk
@@ -3,8 +3,8 @@
 <title>{{doc.fields.title}}</title>
 <meta name="description" value="{{doc.fields.description}}">
 <link href="//fonts.googleapis.com/css?family=Nunito&amp;display=swap" rel="stylesheet" type="text/css">
-<link rel="stylesheet" href="{{pod.staticFile('/dist/css/main.css').url.path}}">
-<script src="{{pod.staticFile('/dist/js/main.js').url.path}}"></script>
+<link rel="stylesheet" href="{{pod.staticFile('/dist/css/main.css')|url}}">
+<script src="{{pod.staticFile('/dist/js/main.js')|url}}"></script>
 <body>
 <div class="main">
     {% set partial = pod.doc('/content/partials/header.yaml').fields %}

--- a/src/document.ts
+++ b/src/document.ts
@@ -4,6 +4,7 @@ import * as utils from './utils';
 
 import {Locale, LocaleSet} from './locale';
 
+import {Collection} from './collection';
 import {DeepWalk} from '@blinkk/editor/dist/src/utility/deepWalk';
 import {Environment} from './environment';
 import {Pod} from './pod';
@@ -189,7 +190,7 @@ export class Document {
    * within the document's content directory, the directory structure will be
    * walked upwards until locating a `_collection.yaml`.
    */
-  get collection() {
+  get collection(): Collection | null {
     return this.pod.collection(fsPath.dirname(this.podPath));
   }
 
@@ -245,6 +246,15 @@ export class Document {
     } finally {
       timer.stop();
     }
+  }
+
+  /**
+   * Returns the document localized to a different locale.
+   * @param locale The locale to use when localizing the document.
+   * @returns The localized document.
+   */
+  localize(locale: Locale) {
+    return this.pod.doc(this.podPath, locale);
   }
 
   async render(context?: Record<string, any>): Promise<string> {

--- a/src/plugins/yaml.test.ts
+++ b/src/plugins/yaml.test.ts
@@ -10,7 +10,7 @@ test('Inbuilt YAML types', (t: ExecutionContext) => {
   t.deepEqual(doc.fields.doc.simple, pod.doc('/content/pages/index.yaml'));
   t.deepEqual(
     doc.fields.doc.options,
-    pod.doc('/content/pages/index.yaml', pod.locale('de'))
+    pod.doc('/content/pages/index.yaml', pod.locale('en'))
   );
   t.deepEqual(
     doc.fields.docs.simple,
@@ -59,6 +59,10 @@ test('Inbuilt YAML types', (t: ExecutionContext) => {
     pod.locale('de')
   ) as Document;
   t.deepEqual(deDoc.fields.IfLocale, 'de Value');
+  t.deepEqual(
+    deDoc.fields.doc.options,
+    pod.doc('/content/pages/index.yaml', pod.locale('de'))
+  );
 
   const jaDoc = pod.doc(
     '/content/pages/index.yaml',

--- a/src/url.test.ts
+++ b/src/url.test.ts
@@ -1,5 +1,7 @@
+import {Document} from './document';
 import {ExecutionContext} from 'ava';
 import {Pod} from './pod';
+import {StaticFile} from './staticFile';
 import {Url} from './url';
 import test from 'ava';
 
@@ -27,5 +29,76 @@ test('relative', async (t: ExecutionContext) => {
       pod.doc('/content/pages/index.yaml')
     ),
     './about/'
+  );
+});
+
+test('common', async (t: ExecutionContext) => {
+  const pod = new Pod('./fixtures/simple/');
+  await pod.warmup();
+  const doc1 = pod.doc('/content/pages/index.yaml') as Document;
+  const doc2 = pod.doc(
+    '/content/pages/about.yaml',
+    pod.locale('de')
+  ) as Document;
+  // No context.
+  t.deepEqual(Url.common(doc1), '/');
+  // Context, default options.
+  t.deepEqual(
+    Url.common(doc1, {
+      context: doc2,
+    }),
+    './../'
+  );
+  // Context, default options, not relative.
+  t.deepEqual(
+    Url.common(doc1, {
+      context: doc2,
+      relative: false,
+    }),
+    '/intl/de/'
+  );
+  // Context, default options, not localized.
+  t.deepEqual(
+    Url.common(doc1, {
+      context: doc2,
+      localize: false,
+    }),
+    './../../../'
+  );
+  // Context, default options, not localized, not relative.
+  t.deepEqual(
+    Url.common(doc1, {
+      context: doc2,
+      relative: false,
+      localize: false,
+    }),
+    '/'
+  );
+  const file = pod.staticFile('/static/images/cat.jpg') as StaticFile;
+  // No context.
+  t.deepEqual(
+    Url.common(file),
+    '/static/images/cat.jpg?fingerprint=42d9f30a2585cd338a609364740b6493'
+  );
+  // Context, default options.
+  t.deepEqual(
+    Url.common(file, {
+      context: doc1,
+    }),
+    './static/images/cat.jpg?fingerprint=42d9f30a2585cd338a609364740b6493'
+  );
+  t.deepEqual(
+    Url.common(file, {
+      context: doc2,
+    }),
+    './../../../static/images/cat.jpg?fingerprint=42d9f30a2585cd338a609364740b6493'
+  );
+  // Context, no fingerprint.
+  t.deepEqual(
+    Url.common(file, {
+      context: doc2,
+      fingerprint: false,
+    }),
+    './../../../static/images/cat.jpg'
   );
 });

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,6 +1,8 @@
 import * as fsPath from 'path';
+
 import {Document} from './document';
 import {Environment} from './environment';
+import {StaticFile} from './staticFile';
 
 interface UrlOptions {
   path: string;
@@ -9,6 +11,9 @@ interface UrlOptions {
   port?: string;
   env?: Environment;
 }
+
+/** Types that can be represented as URLs. */
+export type Urlable = StaticFile | Document | string;
 
 const ABSOLUTE_URL_REGEX = new RegExp('^(//|[a-z]+:)', 'i');
 
@@ -59,9 +64,15 @@ export class Url {
    * @param base The `Document` or URL being linked from.
    * @returns The URL of `other` relative to `base`.
    */
-  static relative(other: Document | string, base: Document | string) {
-    const otherUrl = other instanceof Document ? other.url?.path : other;
-    const baseUrl = base instanceof Document ? base.url?.path : base;
+  static relative(other: Urlable, base: Urlable) {
+    const otherUrl =
+      other instanceof Document || other instanceof StaticFile
+        ? other.url?.path
+        : other;
+    const baseUrl =
+      base instanceof Document || base instanceof StaticFile
+        ? base.url?.path
+        : base;
     if (!otherUrl || !baseUrl || ABSOLUTE_URL_REGEX.test(otherUrl)) {
       return otherUrl;
     }


### PR DESCRIPTION
- This adds a `localize` method to documents which fixes a bug where `!pod.doc` yaml type was used, a document in the pod's default locale would be returned rather than a (better default) where the current document's locale is returned.
- Adds an extremely useful `url` nunjucks filter which adds the [functionality from here](https://github.com/blinkk/amagaki-starter/blob/main/amagaki.ts#L32) to core