### PR TITLE
feat: Add request to the route building.

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -9,8 +9,9 @@ import {Environment} from './environment';
 import {Pod} from './pod';
 import {Route} from './router';
 import {Url} from './url';
-import express from 'express';
 import minimatch from 'minimatch';
+
+import express = require('express');
 
 const DEFAULT_VIEW = '/views/base.njk';
 

--- a/src/document.ts
+++ b/src/document.ts
@@ -7,7 +7,9 @@ import {Locale, LocaleSet} from './locale';
 import {DeepWalk} from '@blinkk/editor/dist/src/utility/deepWalk';
 import {Environment} from './environment';
 import {Pod} from './pod';
+import {Route} from './router';
 import {Url} from './url';
+import express from 'express';
 import minimatch from 'minimatch';
 
 const DEFAULT_VIEW = '/views/base.njk';
@@ -22,6 +24,8 @@ export interface TemplateContext {
   env: Environment;
   pod: Pod;
   process: NodeJS.Process;
+  req?: express.Request;
+  route?: Route;
 }
 
 export interface DocumentListOptions {

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,7 @@ import {Locale} from './locale';
 import {Pod} from './pod';
 import {StaticFile} from './staticFile';
 import {Url} from './url';
+import express from 'express';
 
 export interface StaticDirConfig {
   path: string;
@@ -223,7 +224,8 @@ export class Route {
     this.pod = this.provider.pod;
   }
 
-  async build(): Promise<string> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async build(req?: express.Request): Promise<string> {
     throw new Error('Subclasses of Route must implement a `build` getter.');
   }
 
@@ -263,9 +265,10 @@ export class DocumentRoute extends Route {
     return `[DocumentRoute: ${this.doc}]`;
   }
 
-  async build(): Promise<string> {
+  async build(req?: express.Request): Promise<string> {
     try {
       return await this.doc.render({
+        req: req,
         route: this,
       });
     } catch (err) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -10,6 +10,10 @@ import {Url} from './url';
 
 import express = require('express');
 
+export interface BuildOptions {
+  req?: express.Request;
+}
+
 export interface StaticDirConfig {
   path: string;
   staticDir: string;
@@ -226,7 +230,7 @@ export class Route {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async build(req?: express.Request): Promise<string> {
+  async build(options?: BuildOptions): Promise<string> {
     throw new Error('Subclasses of Route must implement a `build` getter.');
   }
 
@@ -266,10 +270,10 @@ export class DocumentRoute extends Route {
     return `[DocumentRoute: ${this.doc}]`;
   }
 
-  async build(req?: express.Request): Promise<string> {
+  async build(options?: BuildOptions): Promise<string> {
     try {
       return await this.doc.render({
-        req: req,
+        req: options?.req,
         route: this,
       });
     } catch (err) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,7 +7,8 @@ import {Locale} from './locale';
 import {Pod} from './pod';
 import {StaticFile} from './staticFile';
 import {Url} from './url';
-import express from 'express';
+
+import express = require('express');
 
 export interface StaticDirConfig {
   path: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,7 +71,9 @@ export class Server extends events.EventEmitter {
           );
           return;
         } else {
-          const content = await route.build(req);
+          const content = await route.build({
+            req: req,
+          });
           res.set('Content-Type', route.contentType);
           res.send(content);
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,7 +71,7 @@ export class Server extends events.EventEmitter {
           );
           return;
         } else {
-          const content = await route.build();
+          const content = await route.build(req);
           res.set('Content-Type', route.contentType);
           res.send(content);
         }


### PR DESCRIPTION
When building the documents on the dev server or in a preview server setting the build can pass along the request from express to allow the templates to be customized based on things like query params.

An example use case would be the 'help' text to show the partial and option information. Instead of needing to hide it with css, the template can use the request params to determine if the help information should even be rendered.