### PR TITLE
fix: rename route.path to route.podPath and add sample provider

### DIFF
--- a/fixtures/sampleRouteProvider/amagaki.ts
+++ b/fixtures/sampleRouteProvider/amagaki.ts
@@ -1,0 +1,68 @@
+import {Pod, Route, RouteProvider, Router} from '../../src';
+
+export interface SampleRouteProviderOptions {
+  slugs: string[];
+  view: string;
+}
+
+export interface SampleRouteOptions {
+  slug: string;
+  view: string;
+}
+
+export class SampleRouteProvider extends RouteProvider {
+  options: SampleRouteProviderOptions;
+  static type = 'sample';
+
+  constructor(router: Router, options: SampleRouteProviderOptions) {
+    super(router);
+    this.options = options;
+  }
+
+  async routes(): Promise<SampleRoute[]> {
+    return this.options.slugs.map(slug => {
+      return new SampleRoute(this, {
+        slug: slug,
+        view: this.options.view,
+      });
+    });
+  }
+}
+
+export class SampleRoute extends Route {
+  fields: Record<string, any>;
+  options: SampleRouteOptions;
+  view: string;
+
+  constructor(provider: RouteProvider, options: SampleRouteOptions) {
+    super(provider);
+    this.options = options;
+    this.view = options.view;
+    this.fields = {
+      slug: options.slug,
+    };
+  }
+
+  get urlPath() {
+    return `/samples/${this.fields.slug}/`;
+  }
+
+  async build() {
+    const context = {
+      doc: this.fields,
+      env: this.pod.env,
+      pod: this.pod,
+      process: process,
+    };
+    const templateEngine = this.pod.engines.getEngineByFilename(this.view);
+    return templateEngine.render(this.view, context);
+  }
+}
+
+export default function (pod: Pod) {
+  const provider = new SampleRouteProvider(pod.router, {
+    slugs: ['rex', 'cody', 'jesse'],
+    view: '/views/base.njk',
+  });
+  pod.router.addProvider(provider);
+}

--- a/fixtures/sampleRouteProvider/views/base.njk
+++ b/fixtures/sampleRouteProvider/views/base.njk
@@ -1,0 +1,1 @@
+<title>{{doc.slug}}</title>

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -361,7 +361,7 @@ export class Builder {
               `builder.build${urlPathStub}`,
               `Build: ${createdPath.route.urlPath}`,
               {
-                path: createdPath.route.path,
+                path: createdPath.route.podPath,
                 type: createdPath.route.provider.type,
                 urlPath: createdPath.route.urlPath,
               }

--- a/src/document.ts
+++ b/src/document.ts
@@ -4,6 +4,7 @@ import * as utils from './utils';
 
 import {Locale, LocaleSet} from './locale';
 
+import {Collection} from './collection';
 import {DeepWalk} from '@blinkk/editor/dist/src/utility/deepWalk';
 import {Environment} from './environment';
 import {Pod} from './pod';
@@ -194,7 +195,7 @@ export class Document {
    * within the document's content directory, the directory structure will be
    * walked upwards until locating a `_collection.yaml`.
    */
-  get collection() {
+  get collection(): Collection | null {
     return this.pod.collection(fsPath.dirname(this.podPath));
   }
 

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -7,3 +7,15 @@ test('StaticRoute contentType', async (t: ExecutionContext) => {
   const route = await pod.router.resolve('/static/file.txt');
   t.deepEqual(route?.contentType, 'text/plain; charset=utf-8');
 });
+
+test('SampleRouteProvider', async (t: ExecutionContext) => {
+  const pod = new Pod('./fixtures/sampleRouteProvider/');
+  await pod.warmup();
+  // Build the whole site.
+  const result = await pod.builder.export();
+  t.true(result.manifest.files.length === 3);
+  // Build one page by URL.
+  const route = await pod.router.resolve('/samples/rex/');
+  const html = await route?.build();
+  t.deepEqual('<title>rex</title>', html);
+});


### PR DESCRIPTION
- Adds a sample custom route provider showing how to extend Amagaki with custom routes (e.g. from a database)
- Renames `Route` property `path` to `podPath` for correctness
- Uses html as the default route content type for developer ergonomics