### PR TITLE
feat: add support for per-template profiling #25

### DIFF
--- a/src/plugins/nunjucks.ts
+++ b/src/plugins/nunjucks.ts
@@ -140,26 +140,41 @@ export class NunjucksTemplateEngine implements TemplateEngineComponent {
     this.env.addFilter('t', NunjucksBuiltInFilters.t);
   }
 
+  getTimer(podPath?: string) {
+    podPath = podPath || 'self';
+    return this.pod.profiler.timer(
+      `templates.render.${podPath}`,
+      'Template render',
+      {
+        podPath: podPath,
+      }
+    );
+  }
+
   render(path: string, context: any): Promise<string> {
     return new Promise((resolve, reject) => {
+      const timer = this.getTimer(path);
       this.env.render(path, context, (err, res) => {
         if (err) {
           reject(err);
           return;
         }
         resolve(res || '');
+        timer.stop();
       });
     });
   }
 
   renderFromString(template: string, context: any): Promise<string> {
     return new Promise((resolve, reject) => {
+      const timer = this.getTimer();
       this.env.renderString(template, context, (err, res) => {
         if (err) {
           reject(err);
           return;
         }
         resolve(res || '');
+        timer.stop();
       });
     });
   }


### PR DESCRIPTION
When used with a Nunjucks global that invokes the timer, we get the following result with this:

```
┌─────────────────────────────────────────┬──────────┬─────────────────┬─────────────────────────────────────────────────┐
│ Templates                               │        % │            Time │ Stats                                           │
│ /views/base.njk                         │ 1085.26% │ 23 sec, 377.0ms │ 22 calls, 1 sec, 987.0ms max, 1 sec, 62.6ms avg │
│ /views/partials/image-with-text.njk     │   21.24% │         457.5ms │ 40 calls, 19.5ms max, 11.4ms avg                │
│ /views/partials/centered-video.njk      │    4.07% │          87.6ms │ 8 calls, 16.9ms max, 10.9ms avg                 │
│ /views/partials/feature-touts.njk       │    3.34% │          72.0ms │ 4 calls, 21.2ms max, 18.0ms avg                 │
│ /views/partials/two-column-list.njk     │    1.44% │          30.9ms │ 2 calls, 18.5ms max, 15.5ms avg                 │
│ /views/partials/homepage-hero.njk       │    1.16% │          25.1ms │ 2 calls, 13.0ms max, 12.5ms avg                 │
│ /views/partials/secondary-hero.njk      │   12.44% │         268.0ms │ 14 calls, 80.5ms max, 19.1ms avg                │
│ /views/partials/image-with-colorbar.njk │    6.68% │         144.0ms │ 12 calls, 16.0ms max, 12.0ms avg                │
│ /views/partials/explore-cards.njk       │    5.75% │         123.8ms │ 14 calls, 13.6ms max, 8.8ms avg                 │
│ /views/partials/two-column-article.njk  │   19.51% │         420.2ms │ 34 calls, 28.0ms max, 12.4ms avg                │
│ /views/partials/header.njk              │    6.42% │         138.3ms │ 22 calls, 13.6ms max, 6.3ms avg                 │
│ /views/partials/primary-hero.njk        │    2.46% │          53.0ms │ 6 calls, 12.4ms max, 8.8ms avg                  │
│ /views/partials/two-column-text.njk     │    0.69% │          14.8ms │ 2 calls, 8.6ms max, 7.4ms avg                   │
└─────────────────────────────────────────┴──────────┴─────────────────┴─────────────────────────────────────────────────┘

```