### PR TITLE
feat: support appended site name in og:title

### DIFF
--- a/packages/amagaki-plugin-page-builder/src/page-builder.ts
+++ b/packages/amagaki-plugin-page-builder/src/page-builder.ts
@@ -560,7 +560,7 @@ export class PageBuilder {
     url: string;
   }) {
     return html`
-      ${options.title ? html`<title>${options.title} ${options.appendSiteName ? ` | ${options.siteName}` : ''}</title>` : ''}
+      ${options.title ? html`<title>${options.title}${options.appendSiteName ? ` | ${options.siteName}` : ''}</title>` : ''}
       ${options.description
         ? html`<meta name="description" content="${options.description}">`
         : ''}
@@ -576,7 +576,7 @@ export class PageBuilder {
         : ''}
       <meta property="og:url" content="${options.url}">
       ${options.title
-        ? html`<meta property="og:title" content="${options.title}">`
+        ? html`<meta property="og:title" content="${options.title}${options.appendSiteName ? ` | ${options.siteName}` : ''}">`
         : ''}
       ${options.description
         ? html`<meta
@@ -602,7 +602,7 @@ export class PageBuilder {
          >`
         : ''}
       ${options.title
-        ? html`<meta property="twitter:title" content="${options.title}">`
+        ? html`<meta property="twitter:title" content="${options.title}${options.appendSiteName ? ` | ${options.siteName}` : ''}">`
         : ''}
       ${options.description
         ? html`<meta

--- a/packages/amagaki-plugin-page-builder/src/partial-preview.test.ts
+++ b/packages/amagaki-plugin-page-builder/src/partial-preview.test.ts
@@ -23,9 +23,9 @@ test('PatialPreview', async (t: ExecutionContext) => {
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Example">
   <meta property="og:url" content="http://localhost/preview/">
-  <meta property="og:title" content="Preview Gallery">
+  <meta property="og:title" content="Preview Gallery | Example">
   <meta property="og:locale" content="en">
-  <meta property="twitter:title" content="Preview Gallery">
+  <meta property="twitter:title" content="Preview Gallery | Example">
   <meta property="twitter:card" content="summary_large_image">
   <link href="http://localhost/preview/" rel="canonical">
   <link href="https://fonts.googleapis.com/css?family=Material+Icons|Roboto:400,500,700&amp;display=swap" rel="stylesheet" rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'">


### PR DESCRIPTION
Background:

1. `og:site_name` is an optional tag, but recommended (https://ogp.me/)

2. Social sites will use the `<title>` tag as a fallback if `og:title` is missing

3. IMDB, the example used on the OGP website, includes the site name in both the title tag and og:title on there actual site (but not in the example on ogp.me)

4. FB doesn't use/show og:site_name in the share dialog (https://developers.facebook.com/support/bugs/1153386624699119/?comment_id=223306658072032)

It seems like the general consensus is the `og:site_name` is a nice-to-have, but not really used by social sites. General practice is to make the `og:title` and `title` consistent, as they both are meant to represent the title of the current page. It's also common SEO practice to include the site name in the page title, but there's no real "gain" from what I've read outside of branding.