### PR TITLE
fix: alt text will only show once on a11y highlighter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "packages/website"
       ],
       "devDependencies": {
-        "@types/node": "^16.4.10",
+        "@types/node": "^18.11.18",
         "ava": "^4.0.1",
         "esbuild": "^0.14.23",
         "eslint": "^7.15.0",
@@ -568,9 +568,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.11.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.25.tgz",
-      "integrity": "sha512-NrTwfD7L1RTc2qrHQD4RTTy4p0CO2LatKBEKEds3CaVuhoM/+DJzmWZl5f+ikR8cm8F5mfJxK+9rQq07gRiSjQ=="
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -16428,7 +16428,7 @@
         "@types/js-yaml": "^4.0.1",
         "@types/marked": "^2.0.2",
         "@types/mime-types": "^2.1.0",
-        "@types/node": "^15.0.1",
+        "@types/node": "^18.11.18",
         "@types/nunjucks": "^3.1.4",
         "@types/semver": "^7.3.5",
         "ava": "^4.0.1",
@@ -16521,7 +16521,7 @@
         "@blinkk/degu": "^2.0.0",
         "@types/gulp": "^4.0.9",
         "@types/js-beautify": "^1.13.3",
-        "@types/node": "^13.11.1",
+        "@types/node": "^18.11.18",
         "@types/nunjucks": "^3.2.0",
         "ava": "^3.14.0",
         "child_process": "^1.0.2",
@@ -16539,12 +16539,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "packages/amagaki-plugin-page-builder/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
-      "dev": true
     },
     "packages/amagaki-plugin-page-builder/node_modules/@typescript-eslint/typescript-estree": {
       "version": "2.31.0",
@@ -18203,11 +18197,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/amagaki/node_modules/@types/node": {
-      "version": "15.14.9",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/amagaki/node_modules/@types/semver": {
       "version": "7.3.5",
       "dev": true,
@@ -18293,7 +18282,7 @@
       },
       "devDependencies": {
         "@types/async-retry": "1.4.2",
-        "@types/node": "^12.6.8",
+        "@types/node": "^18.11.18",
         "@types/parse-github-repo-url": "^1.4.0",
         "@types/prompts": "2.0.1",
         "@types/rimraf": "3.0.0",
@@ -18336,11 +18325,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "packages/create-amagaki/node_modules/@types/node": {
-      "version": "12.20.46",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/create-amagaki/node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -18785,7 +18769,7 @@
         "@types/js-yaml": "^4.0.1",
         "@types/marked": "^2.0.2",
         "@types/mime-types": "^2.1.0",
-        "@types/node": "^15.0.1",
+        "@types/node": "^18.11.18",
         "@types/nunjucks": "^3.1.4",
         "@types/semver": "^7.3.5",
         "async": "^3.2.0",
@@ -18843,10 +18827,6 @@
         },
         "@types/mime-types": {
           "version": "2.1.0",
-          "dev": true
-        },
-        "@types/node": {
-          "version": "15.14.9",
           "dev": true
         },
         "@types/semver": {
@@ -18940,7 +18920,7 @@
         "@shoelace-style/shoelace": "^2.0.0-beta.71",
         "@types/gulp": "^4.0.9",
         "@types/js-beautify": "^1.13.3",
-        "@types/node": "^13.11.1",
+        "@types/node": "^18.11.18",
         "@types/nunjucks": "^3.2.0",
         "ava": "^3.14.0",
         "child_process": "^1.0.2",
@@ -18959,12 +18939,6 @@
         "typescript": "^3.8.3"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
-          "dev": true
-        },
         "@typescript-eslint/typescript-estree": {
           "version": "2.31.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.31.0.tgz",
@@ -20609,9 +20583,9 @@
       }
     },
     "@types/node": {
-      "version": "16.11.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.25.tgz",
-      "integrity": "sha512-NrTwfD7L1RTc2qrHQD4RTTy4p0CO2LatKBEKEds3CaVuhoM/+DJzmWZl5f+ikR8cm8F5mfJxK+9rQq07gRiSjQ=="
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -23899,7 +23873,7 @@
       "version": "file:packages/create-amagaki",
       "requires": {
         "@types/async-retry": "1.4.2",
-        "@types/node": "^12.6.8",
+        "@types/node": "^18.11.18",
         "@types/parse-github-repo-url": "^1.4.0",
         "@types/prompts": "2.0.1",
         "@types/rimraf": "3.0.0",
@@ -23928,10 +23902,6 @@
           "requires": {
             "defer-to-connect": "^2.0.0"
           }
-        },
-        "@types/node": {
-          "version": "12.20.46",
-          "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16509,7 +16509,7 @@
     },
     "packages/amagaki-plugin-page-builder": {
       "name": "@amagaki/amagaki-plugin-page-builder",
-      "version": "3.8.2",
+      "version": "3.10.0",
       "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.0.0-beta.71",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/website"
   ],
   "devDependencies": {
-    "@types/node": "^16.4.10",
+    "@types/node": "^18.11.18",
     "ava": "^4.0.1",
     "esbuild": "^0.14.23",
     "eslint": "^7.15.0",

--- a/packages/amagaki-plugin-page-builder/example/content/pages/index.yaml
+++ b/packages/amagaki-plugin-page-builder/example/content/pages/index.yaml
@@ -1,18 +1,21 @@
 title: Homepage
 partials:
-- partial: hero
-  title: Hello World 1!
-  image:
-    url: 'data:image/gif;base64,R0lGODlhEAAOALMAAOazToeHh0tLS/7LZv/0jvb29t/f3//Ub//ge8WSLf/rhf/3kdbW1mxsbP//mf///yH5BAAAAAAALAAAAAAQAA4AAARe8L1Ekyky67QZ1hLnjM5UUde0ECwLJoExKcppV0aCcGCmTIHEIUEqjgaORCMxIC6e0CcguWw6aFjsVMkkIr7g77ZKPJjPZqIyd7sJAgVGoEGv2xsBxqNgYPj/gAwXEQA7'
-    alt: 'Alt text'
-- partial: spacer
-# No partial defined, skip.
-- foo: bar
-- partial: hero
-  title: Hello World 2!
-  editContentLink: 'https://example.com/edit-content'
-  submitIssueLink: 'https://example.com/submit-issue'
-- partial: spacer
-- partial: absolute
-  absolutePath: /views/absolute.njk
-  title: Absolute Partial
+  - partial: hero
+    title: Hello World 1!
+    image:
+      url: 'data:image/gif;base64,R0lGODlhEAAOALMAAOazToeHh0tLS/7LZv/0jvb29t/f3//Ub//ge8WSLf/rhf/3kdbW1mxsbP//mf///yH5BAAAAAAALAAAAAAQAA4AAARe8L1Ekyky67QZ1hLnjM5UUde0ECwLJoExKcppV0aCcGCmTIHEIUEqjgaORCMxIC6e0CcguWw6aFjsVMkkIr7g77ZKPJjPZqIyd7sJAgVGoEGv2xsBxqNgYPj/gAwXEQA7'
+      alt: 'Alt text'
+  - partial: spacer
+  # No partial defined, skip.
+  - foo: bar
+  - partial: hero
+    title: Hello World 2!
+    asset:
+      url: https://placeholder-dot-madebygoog.appspot.com/50x50.svg
+      alt: 'Alt text 2'
+    editContentLink: 'https://example.com/edit-content'
+    submitIssueLink: 'https://example.com/submit-issue'
+  - partial: spacer
+  - partial: absolute
+    absolutePath: /views/absolute.njk
+    title: Absolute Partial

--- a/packages/amagaki-plugin-page-builder/example/views/partials/hero.njk
+++ b/packages/amagaki-plugin-page-builder/example/views/partials/hero.njk
@@ -8,9 +8,15 @@
     <h1>{{partial.title}}</h1>
   </div>
   {% if partial.image %}
-  <div class="hero__images">
-    <img src="{{partial.image.url}}" alt="{{partial.image.alt}}">
-  </div>
+    <div class="hero__images">
+      <img src="{{partial.image.url}}" alt="{{partial.image.alt}}">
+    </div>
+  {% endif %}
+  {% if partial.asset %}
+    {# This tests that non-img elements with an alt attribute won't appear in attribute highlighter #}
+    <div class="hero__images" alt="{{partial.asset.alt}}">
+      <img src="{{partial.asset.url}}" alt="{{partial.asset.alt}}">
+    </div>
   {% endif %}
   <div class="hero__footnotes">
     Footnotes

--- a/packages/amagaki-plugin-page-builder/package.json
+++ b/packages/amagaki-plugin-page-builder/package.json
@@ -40,7 +40,7 @@
     "@blinkk/degu": "^2.0.0",
     "@types/gulp": "^4.0.9",
     "@types/js-beautify": "^1.13.3",
-    "@types/node": "^13.11.1",
+    "@types/node": "^18.11.18",
     "@types/nunjucks": "^3.2.0",
     "ava": "^3.14.0",
     "child_process": "^1.0.2",

--- a/packages/amagaki-plugin-page-builder/src/ui/attribute-highlighter.ts
+++ b/packages/amagaki-plugin-page-builder/src/ui/attribute-highlighter.ts
@@ -74,7 +74,10 @@ export class AttributeHighlighter extends LitElement {
       this.attributeHighlighter = new DeguAttributeHighlighter({
         cssClassName: 'attribute-highlighter',
         scopeQuerySelector: 'page-module',
-        attributes: ['alt', 'aria-label'],
+        attributes: [
+          {attribute: 'alt', querySelector: 'img'},
+          {attribute: 'aria-label', querySelector: 'img'},
+        ],
         warnMissingAttributes: [
           {
             attribute: 'alt',

--- a/packages/amagaki/package.json
+++ b/packages/amagaki/package.json
@@ -57,7 +57,7 @@
     "@types/js-yaml": "^4.0.1",
     "@types/marked": "^2.0.2",
     "@types/mime-types": "^2.1.0",
-    "@types/node": "^15.0.1",
+    "@types/node": "^18.11.18",
     "@types/nunjucks": "^3.1.4",
     "@types/semver": "^7.3.5",
     "ava": "^4.0.1",

--- a/packages/create-amagaki/package.json
+++ b/packages/create-amagaki/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/async-retry": "1.4.2",
-    "@types/node": "^12.6.8",
+    "@types/node": "^18.11.18",
     "@types/parse-github-repo-url": "^1.4.0",
     "@types/prompts": "2.0.1",
     "@types/rimraf": "3.0.0",

--- a/packages/create-amagaki/src/utils.ts
+++ b/packages/create-amagaki/src/utils.ts
@@ -39,9 +39,7 @@ export function downloadAndExtractRepo(
   );
 }
 
-export function validateName(
-  name: string
-): {
+export function validateName(name: string): {
   valid: boolean;
   problems?: string[];
 } {
@@ -80,10 +78,7 @@ export async function isWritable(directory: string): Promise<boolean> {
   }
 }
 
-export function makeDir(
-  root: string,
-  options = {recursive: true}
-): Promise<void> {
+export function makeDir(root: string, options = {recursive: true}) {
   return fs.promises.mkdir(root, options);
 }
 


### PR DESCRIPTION
- Add `querySelector` key to each a11y attribute to make sure the labels only show on `img` elements