### PR TITLE
fix!: Change `afterRender` hook to be a sync trigger.

### DIFF
--- a/packages/amagaki/src/plugins.ts
+++ b/packages/amagaki/src/plugins.ts
@@ -16,12 +16,12 @@ export interface PluginComponent {
    */
   afterBuildHook?: (result: BuildResult) => Promise<void>;
   /**
-   * Hook for modifying the content after rendering.
+   * Hook for synchronously modifying the content after rendering.
    *
    * Note: This hook is called from the Template Engine, not all template
    * engines support this hook.
    */
-  afterRenderHook?: (result: TemplateEngineRenderResult) => Promise<void>;
+  afterRenderHook?: (result: TemplateEngineRenderResult) => void;
   /**
    * Hook for working with the builder before the build is executed.
    */

--- a/packages/amagaki/src/plugins/nunjucks.ts
+++ b/packages/amagaki/src/plugins/nunjucks.ts
@@ -192,7 +192,7 @@ export class NunjucksTemplateEngine implements TemplateEngineComponent {
     };
 
     const afterTimer = this.getTimerAfterRender(path);
-    await this.pod.plugins.trigger('afterRender', renderResult);
+    this.pod.plugins.triggerSync('afterRender', renderResult);
     afterTimer.stop();
 
     return renderResult.content || '';
@@ -221,7 +221,7 @@ export class NunjucksTemplateEngine implements TemplateEngineComponent {
     };
 
     const afterTimer = this.getTimerAfterRender();
-    await this.pod.plugins.trigger('afterRender', renderResult);
+    this.pod.plugins.triggerSync('afterRender', renderResult);
     afterTimer.stop();
 
     return renderResult.content || '';


### PR DESCRIPTION
Updates the afterRender hook to not be async since it needs to use the results of the previous plugin to make the next set of changes.