### PR TITLE
fix: Remove extra threshold reporting to clean up default builds.

### DIFF
--- a/packages/amagaki/src/profile.ts
+++ b/packages/amagaki/src/profile.ts
@@ -251,13 +251,12 @@ export class ProfileReport {
   }
 
   output(showExpandedReport = false) {
-    const shownTimerKeys: Set<string> = new Set();
-    this.reportThreshold(shownTimerKeys);
-
     if (!showExpandedReport) {
       return;
     }
 
+    const shownTimerKeys: Set<string> = new Set();
+    this.reportThreshold(shownTimerKeys);
     this.reportHooks(shownTimerKeys);
     this.reportTimers(shownTimerKeys);
     this.reportSlowBuilds(shownTimerKeys);


### PR DESCRIPTION
Since the threshold reporting doesn't really give anything actionable move it behind the normal profiling flag.