### PR TITLE
feat: Use mangled plugin for email addresses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -564,6 +564,12 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
+    "node_modules/@types/marked": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.1.tgz",
+      "integrity": "sha512-Y3pAUzHKh605fN6fvASsz5FDSWbZcs/65Q6xYRmnIP9ZIYz27T4IOmXfH9gWJV1dpi7f1e7z7nBGUTx/a0ptpA==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -6636,6 +6642,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -15544,7 +15555,7 @@
     },
     "packages/amagaki": {
       "name": "@amagaki/amagaki",
-      "version": "2.2.3",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@blinkk/editor.dev-ui": "^3.11.1",
@@ -15560,7 +15571,9 @@
         "i": "^0.3.7",
         "isomorphic-git": "^1.12.1",
         "js-yaml": "^4.1.0",
-        "marked": "^2.0.3",
+        "marked": "^5.1.1",
+        "marked-gfm-heading-id": "^3.0.4",
+        "marked-mangle": "^1.1.2",
         "mime-types": "^2.1.30",
         "minimatch": "^3.0.4",
         "nunjucks": "^3.2.3",
@@ -15578,7 +15591,7 @@
         "@types/express-serve-static-core": "^4.17.21",
         "@types/glob": "^7.1.3",
         "@types/js-yaml": "^4.0.1",
-        "@types/marked": "^2.0.2",
+        "@types/marked": "^5.0.0",
         "@types/mime-types": "^2.1.0",
         "@types/node": "^18.11.18",
         "@types/nunjucks": "^3.1.4",
@@ -17339,11 +17352,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/amagaki/node_modules/@types/marked": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/amagaki/node_modules/@types/mime-types": {
       "version": "2.1.0",
       "dev": true,
@@ -17406,6 +17414,36 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/amagaki/node_modules/marked": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "packages/amagaki/node_modules/marked-gfm-heading-id": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/marked-gfm-heading-id/-/marked-gfm-heading-id-3.0.6.tgz",
+      "integrity": "sha512-ot/iTTxvSJpUWv+DJ5aGVj2kxdEpsiKj6NJy6icwcdrVPHsbAE3dZ3Usk4ORt8ke2HKbw83n5Q5jNwSMuAYMSA==",
+      "dependencies": {
+        "github-slugger": "^2.0.0"
+      },
+      "peerDependencies": {
+        "marked": "^4 || ^5 || ^6 || ^7"
+      }
+    },
+    "packages/amagaki/node_modules/marked-mangle": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/marked-mangle/-/marked-mangle-1.1.2.tgz",
+      "integrity": "sha512-+TDSCT4YiXYlSoinMLEzOY6ErY9S1ZuLMjP5OcC6ZWpre93OxCxspFwa5qZ4RIu7X7TH7fnV0CYxEmgvBz4aFg==",
+      "peerDependencies": {
+        "marked": "^4 || ^5 || ^6 || ^7"
       }
     },
     "packages/amagaki/node_modules/ts-loader": {
@@ -17919,7 +17957,7 @@
         "@types/express-serve-static-core": "^4.17.21",
         "@types/glob": "^7.1.3",
         "@types/js-yaml": "^4.0.1",
-        "@types/marked": "^2.0.2",
+        "@types/marked": "^5.0.0",
         "@types/mime-types": "^2.1.0",
         "@types/node": "^18.11.18",
         "@types/nunjucks": "^3.1.4",
@@ -17942,7 +17980,9 @@
         "i": "^0.3.7",
         "isomorphic-git": "^1.12.1",
         "js-yaml": "^4.1.0",
-        "marked": "^2.0.3",
+        "marked": "^5.1.1",
+        "marked-gfm-heading-id": "^3.0.4",
+        "marked-mangle": "^1.1.2",
         "mime-types": "^2.1.30",
         "minimatch": "^3.0.4",
         "nodemon": "^2.0.7",
@@ -17971,10 +18011,6 @@
         },
         "@types/js-yaml": {
           "version": "4.0.1",
-          "dev": true
-        },
-        "@types/marked": {
-          "version": "2.0.2",
           "dev": true
         },
         "@types/mime-types": {
@@ -18014,6 +18050,25 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "marked": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+          "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg=="
+        },
+        "marked-gfm-heading-id": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/marked-gfm-heading-id/-/marked-gfm-heading-id-3.0.6.tgz",
+          "integrity": "sha512-ot/iTTxvSJpUWv+DJ5aGVj2kxdEpsiKj6NJy6icwcdrVPHsbAE3dZ3Usk4ORt8ke2HKbw83n5Q5jNwSMuAYMSA==",
+          "requires": {
+            "github-slugger": "^2.0.0"
+          }
+        },
+        "marked-mangle": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/marked-mangle/-/marked-mangle-1.1.2.tgz",
+          "integrity": "sha512-+TDSCT4YiXYlSoinMLEzOY6ErY9S1ZuLMjP5OcC6ZWpre93OxCxspFwa5qZ4RIu7X7TH7fnV0CYxEmgvBz4aFg==",
+          "requires": {}
         },
         "ts-loader": {
           "version": "9.1.1",
@@ -19699,6 +19754,12 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
+    "@types/marked": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.1.tgz",
+      "integrity": "sha512-Y3pAUzHKh605fN6fvASsz5FDSWbZcs/65Q6xYRmnIP9ZIYz27T4IOmXfH9gWJV1dpi7f1e7z7nBGUTx/a0ptpA==",
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -24427,6 +24488,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-4.0.0.tgz",
       "integrity": "sha512-mH0bcIKv4XAN0mQVokfTdKo2OD5K8WJE9+lbMdM32/q0Ie5tXgVN/2o+zvToRMxSTUuiTRcLg5hzkFfOyBYreg=="
+    },
+    "github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "glob": {
       "version": "7.2.0",

--- a/packages/amagaki/package.json
+++ b/packages/amagaki/package.json
@@ -88,6 +88,7 @@
     "js-yaml": "^4.1.0",
     "marked": "^5.1.1",
     "marked-gfm-heading-id": "^3.0.4",
+    "marked-mangle": "^1.1.2",
     "mime-types": "^2.1.30",
     "minimatch": "^3.0.4",
     "nunjucks": "^3.2.3",

--- a/packages/amagaki/src/plugins/nunjucks.ts
+++ b/packages/amagaki/src/plugins/nunjucks.ts
@@ -10,8 +10,10 @@ import {Url} from '../url';
 import {formatBytes} from '../utils';
 import { marked } from 'marked';
 import { gfmHeadingId } from "marked-gfm-heading-id";
+import { mangle } from "marked-mangle";
 
 marked.use(gfmHeadingId());
+marked.use(mangle());
 
 /**
  * Built-in Nunjucks filters.


### PR DESCRIPTION
The 5.0.0 version of marked doesn't default to mangled email addresses and separates into a separate plugin.