### PR TITLE
fix: Update PluginConstructor to use a generic constructor signature

### DIFF
--- a/.github/workflows/test-amagaki.yml
+++ b/.github/workflows/test-amagaki.yml
@@ -6,8 +6,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
       - name: Run npm tests
@@ -20,7 +20,7 @@ jobs:
         run: |
           ./runAll.sh
       - name: Archive npm failure logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: npm-logs

--- a/packages/amagaki/src/plugins.ts
+++ b/packages/amagaki/src/plugins.ts
@@ -50,8 +50,8 @@ export interface PluginComponent {
   updatePathFormatContextHook?: (context: Record<string, any>) => void;
 }
 
-export interface PluginConstructor {
-  new (pod: Pod, config: Record<string, any>): PluginComponent;
+export interface PluginConstructor<T = Record<string, any>> {
+  new (pod: Pod, config: T): PluginComponent;
 }
 
 /**


### PR DESCRIPTION
When implementing `PluginComponent`, we're currently unable to include required props in the configuration, ie. all props must use the optional modifier `?`

```
export interface RandomConfig {
  prop1?: string;
  prop2?: string;
  prop3?: string[];
}

export class RandomPlugin implements PluginComponent {
  static register(pod: Pod, config: RandomConfig): RandomConfig {
    pod.plugins.register(RandomPlugin, config ?? {});

    return config;
  }
}
```

The configuration is inheriting from PluginComponent's config (`Record<string, any>`) and it currently does not support required props. This change makes the PluginComponent interface generic, and should allow for non-optional props on the child component configs, .ie.

```
export interface RandomConfig {
  prop1: string;
  prop2: string;
  prop3: string[];
}

export class RandomPlugin implements PluginComponent {
  static register(pod: Pod, config: RandomConfig): RandomConfig {
    pod.plugins.register(RandomPlugin, config ?? {});

    return config;
  }
}
```

Change-Id: Id55e61185513ef676bb21f33959ed6ec0276545a